### PR TITLE
Ensure Deploy to GCP Properly Works

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -31,6 +31,16 @@ jobs:
         run: |
           echo "${{ secrets.PHARMAID_GOOGLE_APPLICATION_CREDENTIALS }}" | base64 -d > $GITHUB_WORKSPACE/src/main/resources/bytecoders-coms4156-key.json
 
+      - name: Print variables
+        run: |
+          echo "db_instance: ${{ vars.PHARMAID_DB_CLOUD_SQL_INSTANCE }}"
+          echo "gcp_project: ${{ vars.PHARMAID_GCP_PROJECT_ID }}"
+          echo "db_name: ${{ vars.PHARMAID_DB_NAME }}"
+          echo "db_user: ${{ vars.PHARMAID_DB_USER }}"
+          echo "db_pass: ${{ vars.PHARMAID_DB_PASS }}"
+          echo "GOOGLE_APPLICATION_CREDENTIALS print:"
+          cat $GITHUB_WORKSPACE/src/main/resources/bytecoders-coms4156-key.json | jq .
+
       - name: Authenticate with GCP
         run: gcloud auth activate-service-account --key-file=$GITHUB_WORKSPACE/src/main/resources/bytecoders-coms4156-key.json
 

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Print variables
         run: |
           echo "db_instance: ${{ vars.PHARMAID_DB_CLOUD_SQL_INSTANCE }}"
+          echo "db_instance: $PHARMAID_DB_CLOUD_SQL_INSTANCE"
           echo "gcp_project: ${{ vars.PHARMAID_GCP_PROJECT_ID }}"
+          echo "gcp_project: $PHARMAID_GCP_PROJECT_ID"
           echo "db_name: ${{ vars.PHARMAID_DB_NAME }}"
           echo "db_user: ${{ vars.PHARMAID_DB_USER }}"
           echo "db_pass: ${{ vars.PHARMAID_DB_PASS }}"


### PR DESCRIPTION
## Description
Service is down on App Engine. The problem seems to originate from referencing `classpath` in `spring.cloud.gcp.credentials.location` when deploying via GitHub actions.  [Stack overflow](https://stackoverflow.com/questions/50981257/spring-boot-project-jar-file-not-reading-file-placed-on-classpath). 


## Checklist

- [ ] Tests pass
- [ ] No checkstyle errors
- [ ] No PMD errors
- [ ] No compilation/build errors