### PR TITLE
Debug sharing permissions

### DIFF
--- a/src/main/java/com/bytecoders/pharmaid/repository/SharedPermissionRepository.java
+++ b/src/main/java/com/bytecoders/pharmaid/repository/SharedPermissionRepository.java
@@ -14,18 +14,16 @@ public interface SharedPermissionRepository extends JpaRepository<SharedPermissi
   /**
    * Finds Shared Permission by owner, requester, permissionType and status.
    *
-   * @param owner owner
-   * @param requester requester
+   * @param owner          owner
+   * @param requester      requester
    * @param permissionType 0 is view, 1 is edit
-   * @param status 0 is pending, 1 accepted, 2 denied, revoked ones are deleted
+   * @param status         0 is pending, 1 accepted, 2 denied, revoked ones are deleted
    * @return Optional permission.
    */
-  Optional<SharedPermission> findByOwnerRequesterPermissionStatus(
-      User owner,
+  Optional<SharedPermission> findByOwnerAndRequesterAndPermissionTypeAndStatus(User owner,
       User requester,
       Integer permissionType,
-      Integer status
-  );
+      Integer status);
 
 
 }

--- a/src/main/java/com/bytecoders/pharmaid/service/SharedPermissionService.java
+++ b/src/main/java/com/bytecoders/pharmaid/service/SharedPermissionService.java
@@ -27,27 +27,28 @@ public class SharedPermissionService {
   private static final int EDIT = 1;
 
 
-  @Autowired private SharedPermissionRepository sharedPermissionRepository;
+  @Autowired
+  private SharedPermissionRepository sharedPermissionRepository;
 
-  @Autowired private UserRepository userRepository;
+  @Autowired
+  private UserRepository userRepository;
 
   /**
    * Creates a new sharing request.
    *
-   * @param ownerId Id of owner.
+   * @param ownerId        Id of owner.
    * @param permissionType 0 if view, 1 if edit.
    * @return SharedPermission object.
    */
-  public SharedPermission createSharingRequest(
-      String requesterId, String ownerId, Integer permissionType) {
+  public SharedPermission createSharingRequest(String requesterId,
+      String ownerId,
+      Integer permissionType) {
 
-    User owner =
-        userRepository
-            .findById(ownerId)
-            .orElseThrow(
-                () ->
-                    new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "User not found with ID: " + ownerId));
+    User
+        owner =
+        userRepository.findById(ownerId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                "User not found with ID: " + ownerId));
 
     if (ownerId.equals(requesterId)) {
       throw new IllegalArgumentException("Cannot create shared permission with self");
@@ -57,19 +58,19 @@ public class SharedPermissionService {
       throw new IllegalArgumentException("Permission Type should be view or edit");
     }
 
-    User requester =
-        userRepository
-            .findById(requesterId)
-            .orElseThrow(
-                () ->
-                    new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "User not found with ID: " + requesterId));
+    User
+        requester =
+        userRepository.findById(requesterId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                "User not found with ID: " + requesterId));
 
     // Checks if permission already exists and return it if found.
-    Optional<SharedPermission> existingPermission =
-        sharedPermissionRepository.findByOwnerRequesterPermissionStatus(
-            owner, requester, permissionType, PENDING
-            );
+    Optional<SharedPermission>
+        existingPermission =
+        sharedPermissionRepository.findByOwnerAndRequesterAndPermissionTypeAndStatus(owner,
+            requester,
+            permissionType,
+            PENDING);
 
     if (existingPermission.isPresent()) {
       return existingPermission.get();
@@ -87,37 +88,34 @@ public class SharedPermissionService {
   /**
    * Accepts/Denies a share request.
    *
-   * @param ownerId owner id
+   * @param ownerId      owner id
    * @param permissionId id of permission to be accepted/denied
-   * @param accept 1 if accept, 2 if deny
+   * @param accept       1 if accept, 2 if deny
    * @return SharedPermission object
    */
-  public SharedPermission acceptDenySharingRequest(
-      String ownerId, String permissionId, int accept) {
+  public SharedPermission acceptDenySharingRequest(String ownerId,
+      String permissionId,
+      int accept) {
 
-    SharedPermission permission =
-        sharedPermissionRepository
-            .findById(permissionId)
-            .orElseThrow(
-                () ->
-                    new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, " Request not found with id : " + permissionId));
+    SharedPermission
+        permission =
+        sharedPermissionRepository.findById(permissionId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                " Request not found with id : " + permissionId));
 
     if (!permission.getOwner().getId().equals(ownerId)) {
-      throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN, " Not Authorized to accept this request ");
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+          " Not Authorized to accept this request ");
     }
 
     if (permission.getStatus() != PENDING) {
       throw new IllegalArgumentException("Only Pending Requests can be accepted");
     }
 
-
     if (!(accept == ACCEPT || accept == DENY)) {
       throw new IllegalArgumentException(" Pending Requests must be accepted or rejected ");
 
     }
-
 
     permission.setStatus(accept);
     return sharedPermissionRepository.save(permission);
@@ -126,22 +124,20 @@ public class SharedPermissionService {
   /**
    * Revokes an already accepted share permission.
    *
-   * @param ownerId owner id
+   * @param ownerId      owner id
    * @param permissionId share request id
    */
   public void revokeSharingPermission(String ownerId, String permissionId) {
 
-    SharedPermission permission =
-        sharedPermissionRepository
-            .findById(permissionId)
-            .orElseThrow(
-                () ->
-                    new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, " Request not found with id : " + permissionId));
+    SharedPermission
+        permission =
+        sharedPermissionRepository.findById(permissionId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                " Request not found with id : " + permissionId));
 
     if (!permission.getOwner().getId().equals(ownerId)) {
-      throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN, " Not Authorized to revoke this request ");
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+          " Not Authorized to revoke this request ");
     }
 
     if (permission.getStatus() != ACCEPT) {

--- a/src/main/java/com/bytecoders/pharmaid/util/JwtUtils.java
+++ b/src/main/java/com/bytecoders/pharmaid/util/JwtUtils.java
@@ -9,6 +9,7 @@ import java.security.Key;
 import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Utils to generate, parse, and validate JSON Web Tokens (JWT).
@@ -60,5 +61,15 @@ public class JwtUtils {
   private Key getSignInKey() {
     byte[] keyBytes = Decoders.BASE64.decode(secretKey);
     return Keys.hmacShaKeyFor(keyBytes);
+  }
+
+  public String getLoggedInUserId() {
+    org.springframework.security.core.Authentication
+        authentication =
+        SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null) {
+      return (String) authentication.getPrincipal();
+    }
+    return null;
   }
 }

--- a/src/test/java/com/bytecoders/pharmaid/service/SharedPermissionServiceTests.java
+++ b/src/test/java/com/bytecoders/pharmaid/service/SharedPermissionServiceTests.java
@@ -26,11 +26,14 @@ import org.springframework.web.server.ResponseStatusException;
 @ExtendWith(MockitoExtension.class)
 public class SharedPermissionServiceTests {
 
-  @Mock private SharedPermissionRepository sharedPermissionRepository;
+  @Mock
+  private SharedPermissionRepository sharedPermissionRepository;
 
-  @Mock private UserRepository userRepository;
+  @Mock
+  private UserRepository userRepository;
 
-  @InjectMocks private SharedPermissionService sharedPermissionService;
+  @InjectMocks
+  private SharedPermissionService sharedPermissionService;
 
   private User owner;
   private User requester;
@@ -59,13 +62,15 @@ public class SharedPermissionServiceTests {
     when(userRepository.findById("requester456")).thenReturn(Optional.of(requester));
 
     // permission doesn't already exist
-    when(sharedPermissionRepository.findByOwnerRequesterPermissionStatus(
-            any(), any(), any(), any()))
-        .thenReturn(Optional.empty());
+    when(sharedPermissionRepository.findByOwnerAndRequesterAndPermissionTypeAndStatus(any(),
+        any(),
+        any(),
+        any())).thenReturn(Optional.empty());
 
     when(sharedPermissionRepository.save(any())).thenReturn(permission);
 
-    SharedPermission result =
+    SharedPermission
+        result =
         sharedPermissionService.createSharingRequest("requester456", "owner123", 0);
 
     assertNotNull(result);
@@ -84,11 +89,13 @@ public class SharedPermissionServiceTests {
     when(userRepository.findById("requester456")).thenReturn(Optional.of(requester));
 
     // permission already exists
-    when(sharedPermissionRepository.findByOwnerRequesterPermissionStatus(
-            any(), any(), any(), any()))
-        .thenReturn(Optional.of(permission));
+    when(sharedPermissionRepository.findByOwnerAndRequesterAndPermissionTypeAndStatus(any(),
+        any(),
+        any(),
+        any())).thenReturn(Optional.of(permission));
 
-    SharedPermission result =
+    SharedPermission
+        result =
         sharedPermissionService.createSharingRequest("requester456", "owner123", 0);
 
     assertNotNull(result);
@@ -103,8 +110,7 @@ public class SharedPermissionServiceTests {
     // set up owner doesn't exist
     when(userRepository.findById("owner123")).thenReturn(Optional.empty());
 
-    assertThrows(
-        ResponseStatusException.class,
+    assertThrows(ResponseStatusException.class,
         () -> sharedPermissionService.createSharingRequest("requester456", "owner123", 0));
   }
 
@@ -114,8 +120,7 @@ public class SharedPermissionServiceTests {
     when(userRepository.findById("owner123")).thenReturn(Optional.of(owner));
     when(userRepository.findById("requester456")).thenReturn(Optional.empty());
 
-    assertThrows(
-        ResponseStatusException.class,
+    assertThrows(ResponseStatusException.class,
         () -> sharedPermissionService.createSharingRequest("requester456", "owner123", 0));
   }
 
@@ -125,8 +130,7 @@ public class SharedPermissionServiceTests {
 
     when(userRepository.findById("requester456")).thenReturn(Optional.of(requester));
 
-    assertThrows(
-        IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> sharedPermissionService.createSharingRequest("requester456", "requester456", 0));
   }
 
@@ -136,8 +140,7 @@ public class SharedPermissionServiceTests {
 
     when(userRepository.findById("owner123")).thenReturn(Optional.of(owner));
 
-    assertThrows(
-        IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> sharedPermissionService.createSharingRequest("requester456", "owner123", 2));
   }
 
@@ -148,7 +151,8 @@ public class SharedPermissionServiceTests {
     when(sharedPermissionRepository.findById("permission789")).thenReturn(Optional.of(permission));
     when(sharedPermissionRepository.save(any())).thenReturn(permission);
 
-    SharedPermission result =
+    SharedPermission
+        result =
         sharedPermissionService.acceptDenySharingRequest("owner123", "permission789", 1);
 
     assertNotNull(result);
@@ -163,7 +167,8 @@ public class SharedPermissionServiceTests {
     when(sharedPermissionRepository.findById("permission789")).thenReturn(Optional.of(permission));
     when(sharedPermissionRepository.save(any())).thenReturn(permission);
 
-    SharedPermission result =
+    SharedPermission
+        result =
         sharedPermissionService.acceptDenySharingRequest("owner123", "permission789", 2);
 
     assertNotNull(result);
@@ -176,8 +181,7 @@ public class SharedPermissionServiceTests {
     // request with permission id doesn't exist
     when(sharedPermissionRepository.findById("permission789")).thenReturn(Optional.empty());
 
-    assertThrows(
-        ResponseStatusException.class,
+    assertThrows(ResponseStatusException.class,
         () -> sharedPermissionService.acceptDenySharingRequest("owner123", "permission789", 1));
   }
 
@@ -187,8 +191,7 @@ public class SharedPermissionServiceTests {
     // in before each permission's owner is set
     when(sharedPermissionRepository.findById("permission789")).thenReturn(Optional.of(permission));
 
-    assertThrows(
-        ResponseStatusException.class,
+    assertThrows(ResponseStatusException.class,
         () -> sharedPermissionService.acceptDenySharingRequest("wrongOwner", "permission789", 1));
   }
 
@@ -199,8 +202,7 @@ public class SharedPermissionServiceTests {
     permission.setStatus(1);
     when(sharedPermissionRepository.findById("permission789")).thenReturn(Optional.of(permission));
 
-    assertThrows(
-        IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> sharedPermissionService.acceptDenySharingRequest("owner123", "permission789", 1));
   }
 
@@ -210,8 +212,7 @@ public class SharedPermissionServiceTests {
     when(sharedPermissionRepository.findById("permission789")).thenReturn(Optional.of(permission));
 
     // accept or deny 1 or 2
-    assertThrows(
-        IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> sharedPermissionService.acceptDenySharingRequest("owner123", "permission789", 3));
   }
 
@@ -233,8 +234,7 @@ public class SharedPermissionServiceTests {
     // permission id not found
     when(sharedPermissionRepository.findById("permission789")).thenReturn(Optional.empty());
 
-    assertThrows(
-        ResponseStatusException.class,
+    assertThrows(ResponseStatusException.class,
         () -> sharedPermissionService.revokeSharingPermission("owner123", "permission789"));
   }
 
@@ -245,8 +245,7 @@ public class SharedPermissionServiceTests {
     permission.setStatus(1);
     when(sharedPermissionRepository.findById("permission789")).thenReturn(Optional.of(permission));
 
-    assertThrows(
-        ResponseStatusException.class,
+    assertThrows(ResponseStatusException.class,
         () -> sharedPermissionService.revokeSharingPermission("wrongOwner", "permission789"));
   }
 
@@ -257,8 +256,7 @@ public class SharedPermissionServiceTests {
     when(sharedPermissionRepository.findById("permission789")).thenReturn(Optional.of(permission));
 
     // can't call revoke on a yet to be accepted request
-    assertThrows(
-        IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> sharedPermissionService.revokeSharingPermission("owner123", "permission789"));
   }
 }


### PR DESCRIPTION
## Description
Error with sharing permissions when launching service:
```
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'sharedPermissionService': Unsatisfied dependency expressed through field 'sharedPermissionRepository': Error creating bean with name 'sharedPermissionRepository' defined in com.bytecoders.pharmaid.repository.SharedPermissionRepository defined in @EnableJpaRepositories declared on JpaRepositoriesRegistrar.EnableJpaRepositoriesConfiguration: Could not create query for public abstract java.util.Optional com.bytecoders.pharmaid.repository.SharedPermissionRepository.findByOwnerRequesterPermissionStatus(com.bytecoders.pharmaid.repository.model.User,com.bytecoders.pharmaid.repository.model.User,java.lang.Integer,java.lang.Integer); Reason: Failed to create query for method public abstract java.util.Optional com.bytecoders.pharmaid.repository.SharedPermissionRepository.findByOwnerRequesterPermissionStatus(com.bytecoders.pharmaid.repository.model.User,com.bytecoders.pharmaid.repository.model.User,java.lang.Integer,java.lang.Integer); No property 'requesterPermissionStatus' found for type 'User'; Traversed path: SharedPermission.owner
```

For `getLoggedInUserId()`, I tested by creating a test endpoint getUser():
```
@GetMapping(path = "/users")
  public ResponseEntity<?> getUser() {
    try {
      String userId = jwtUtils.getLoggedInUserId();

      return new ResponseEntity<>(userService.getUser(userId), HttpStatus.OK);
    } catch (Exception e) {
      return new ResponseEntity<>("Unexpected error encountered while retrieving user",
          HttpStatus.INTERNAL_SERVER_ERROR);
    }
  }
```

Import with `import com.bytecoders.pharmaid.util.JwtUtils;` and call with:
```
@Autowired
private JwtUtils jwtUtils;

String userId = jwtUtils.getLoggedInUserId();

// get user object
userService.getUser(userId);
```

I will add tests for all related JWT functionality later this week

## Checklist

- [X] Tests pass
- [X] No checkstyle errors
- [X] No PMD errors
- [X] No compilation/build errors